### PR TITLE
Add DRM error scenario and metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/backend_api/index.js
+++ b/backend_api/index.js
@@ -1,12 +1,21 @@
 const express = require("express");
+const fs = require("fs");
+const client = require("prom-client");
+
 const app = express();
 app.use(express.json());
 
-const videos = [
-  { id: 1, title: "Película A", drm: "Widevine", status: "OK" },
-  { id: 2, title: "Serie B", drm: "FairPlay", status: "OK" },
-  { id: 3, title: "Documental C", drm: "PlayReady", status: "ERROR DRM" },
-];
+// Métricas de Prometheus
+const register = new client.Registry();
+client.collectDefaultMetrics({ register });
+const drmErrorCounter = new client.Counter({
+  name: "drm_error_total",
+  help: "Total de errores de licencia DRM",
+});
+register.registerMetric(drmErrorCounter);
+
+// Cargar videos desde archivo
+const videos = JSON.parse(fs.readFileSync("videos.json", "utf-8"));
 
 // Obtener todos los videos
 app.get("/videos", (req, res) => res.json(videos));
@@ -15,8 +24,17 @@ app.get("/videos", (req, res) => res.json(videos));
 app.get("/videos/:id", (req, res) => {
   const video = videos.find(v => v.id === parseInt(req.params.id));
   if (!video) return res.status(404).json({ error: "Video no encontrado" });
-  if (video.status !== "OK") return res.status(403).json({ error: "Licencia DRM inválida" });
+  if (video.status !== "OK") {
+    drmErrorCounter.inc();
+    return res.status(403).json({ error: "Licencia DRM inválida" });
+  }
   res.json(video);
+});
+
+// Endpoint de métricas
+app.get("/metrics", async (req, res) => {
+  res.set("Content-Type", register.contentType);
+  res.end(await register.metrics());
 });
 
 app.listen(3000, () => console.log("API OTT corriendo en http://localhost:3000"));

--- a/backend_api/package.json
+++ b/backend_api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend_api",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node index.js & pid=$!; sleep 1; kill $pid"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "prom-client": "^14.2.0"
+  }
+}

--- a/backend_api/videos.json
+++ b/backend_api/videos.json
@@ -1,0 +1,5 @@
+[
+  { "id": 1, "title": "Película A", "drm": "Widevine", "status": "OK" },
+  { "id": 2, "title": "Serie B", "drm": "FairPlay", "status": "OK" },
+  { "id": 3, "title": "Documental C", "drm": "PlayReady", "status": "ERROR_DRM" }
+]

--- a/scripts/incident_drm_failure.sh
+++ b/scripts/incident_drm_failure.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Basado en incident_scenarios.sh
+# Simula una solicitud a un video con error de DRM
+
+ID=3
+echo "Solicitando video con ID $ID (espera 403)"
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/videos/$ID

--- a/scripts/incident_video_not_found.sh
+++ b/scripts/incident_video_not_found.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Basado en incident_scenarios.sh
+# Simula solicitud de un video inexistente
+
+ID=999
+echo "Solicitando video con ID $ID (espera 404)"
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/videos/$ID


### PR DESCRIPTION
## Summary
- Load video data from `videos.json` and expose Prometheus metrics tracking DRM failures
- Add example DRM error state in `videos.json`
- Provide scripts to simulate DRM and not-found incident scenarios

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `docker compose restart backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ff212a7c8325803695503c982ef7