### PR TITLE
Add incident scenario orchestrator and health check scripts

### DIFF
--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Verifica el endpoint /health de la API OTT
+
+URL=${1:-http://localhost:3000/health}
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+if [ "$STATUS" -ne 200 ]; then
+  echo "Health check falló (código $STATUS)"
+  exit 1
+fi
+
+echo "Health OK"

--- a/scripts/incident_scenarios.sh
+++ b/scripts/incident_scenarios.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Ejecuta distintos escenarios de fallas en la API OTT
+
+DIR="$(dirname "$0")"
+
+echo "Escenario DRM:"
+"$DIR/incident_drm_failure.sh"
+
+echo "Escenario video no encontrado:"
+"$DIR/incident_video_not_found.sh"
+
+echo "Escenario DB:"
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/simulate-db-error
+
+echo "Escenario CDN:"
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/simulate-cdn-error
+
+echo "Escenario API:"
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/simulate-api-error


### PR DESCRIPTION
## Summary
- add script to run DRM, video-not-found, DB, CDN, and API incident simulations
- add health check script that exits non-zero on failure

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_68b20d9083f0832584960c19a3712cb8