### PR TITLE
Configure Prometheus and Grafana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     ports:
       - "9090:9090"
     volumes:
-      - ./grafana/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
 
   grafana:
     image: grafana/grafana

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'backend'
+    static_configs:
+      - targets: ['backend:3000']


### PR DESCRIPTION
## Summary
- add Prometheus scrape config for backend service
- provision Grafana datasource targeting Prometheus
- update docker-compose to mount Prometheus config from new location

## Testing
- `npm test --prefix backend_api` *(fails: Cannot find module 'express')*
- `npm install --prefix backend_api` *(fails: 403 Forbidden to registry.npmjs.org)*
- `docker-compose config` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b20d9348cc8325a91190a21dc2b57b