### PR TITLE
refactor: simplify backend API with express

### DIFF
--- a/backend_api/index.js
+++ b/backend_api/index.js
@@ -1,98 +1,92 @@
-
-const express = require("express");
-const fs = require("fs");
-const client = require("prom-client");
+const express = require('express');
+const fs = require('fs');
+const client = require('prom-client');
 
 const app = express();
 app.use(express.json());
 
-
-// Métricas de Prometheus
+// Prometheus metrics setup
 const register = new client.Registry();
 client.collectDefaultMetrics({ register });
-const drmErrorCounter = new client.Counter({
-  name: "drm_error_total",
-  help: "Total de errores de licencia DRM",
-});
-register.registerMetric(drmErrorCounter);
 
-// Cargar videos desde archivo
-const videos = JSON.parse(fs.readFileSync("videos.json", "utf-8"));
-
-let licensesIssued = 0;
-
-
-function sendJSON(res, status, data) {
-  res.statusCode = status;
-  res.setHeader("Content-Type", "application/json");
-  res.end(JSON.stringify(data));
-}
-
-const server = http.createServer((req, res) => {
-  const url = new URL(req.url, `http://${req.headers.host}`);
-
-  if (req.method === "GET" && url.pathname === "/videos") {
-    return sendJSON(res, 200, videos);
-  }
-
-  if (req.method === "GET" && url.pathname.startsWith("/videos/")) {
-    const id = parseInt(url.pathname.split("/")[2]);
-    const video = videos.find(v => v.id === id);
-    if (!video) return sendJSON(res, 404, { error: "Video no encontrado" });
-    if (video.status !== "OK") return sendJSON(res, 403, { error: "Licencia DRM inválida" });
-    return sendJSON(res, 200, video);
-  }
-
-  if (req.method === "POST" && url.pathname === "/license") {
-    let body = "";
-    req.on("data", chunk => body += chunk);
-    req.on("end", () => {
-      try {
-        const { videoId } = JSON.parse(body || "{}");
-        const video = videos.find(v => v.id === videoId);
-        if (!video) return sendJSON(res, 404, { error: "Video no encontrado" });
-        licensesIssued++;
-        return sendJSON(res, 200, { license: `LIC-${videoId}` });
-      } catch {
-        return sendJSON(res, 400, { error: "JSON inválido" });
-      }
-    });
-    return;
-  }
-
-  if (req.method === "GET" && url.pathname === "/metrics") {
-    const metrics = `# HELP licenses_issued_total Total licenses issued\n` +
-      `# TYPE licenses_issued_total counter\n` +
-      `licenses_issued_total ${licensesIssued}\n`;
-    res.statusCode = 200;
-    res.setHeader("Content-Type", "text/plain; version=0.0.4");
-    res.end(metrics);
-    return;
-  }
-
-  res.statusCode = 404;
-  res.end("Not found");
+const httpRequestCounter = new client.Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status']
 });
 
-server.listen(3000, () => {
-  console.log("API OTT corriendo en http://localhost:3000");
+const drmFailuresCounter = new client.Counter({
+  name: 'drm_failures_total',
+  help: 'Total number of DRM license failures'
 });
 
-app.get("/videos/:id", (req, res) => {
+const cdnLatencyHistogram = new client.Histogram({
+  name: 'cdn_latency_seconds',
+  help: 'Latency for CDN asset delivery in seconds',
+  labelNames: ['asset'],
+  buckets: [0.1, 0.5, 1, 2, 5]
+});
+
+register.registerMetric(httpRequestCounter);
+register.registerMetric(drmFailuresCounter);
+register.registerMetric(cdnLatencyHistogram);
+
+// Middleware to count HTTP requests
+app.use((req, res, next) => {
+  res.on('finish', () => {
+    const route = req.route ? req.route.path : req.originalUrl;
+    httpRequestCounter.labels(req.method, route, res.statusCode).inc();
+  });
+  next();
+});
+
+// Load videos data
+const videos = JSON.parse(fs.readFileSync('videos.json', 'utf-8'));
+
+// Routes
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.get('/videos', (req, res) => {
+  res.json(videos);
+});
+
+app.get('/videos/:id', (req, res) => {
   const video = videos.find(v => v.id === parseInt(req.params.id));
-  if (!video) return res.status(404).json({ error: "Video no encontrado" });
-  if (video.status !== "OK") {
-    drmErrorCounter.inc();
-    return res.status(403).json({ error: "Licencia DRM inválida" });
+  if (!video) return res.status(404).json({ error: 'Video no encontrado' });
+  if (video.status !== 'OK') {
+    drmFailuresCounter.inc();
+    return res.status(403).json({ error: 'Licencia DRM inválida' });
   }
   res.json(video);
 });
 
-// Endpoint de métricas
-app.get("/metrics", async (req, res) => {
-  res.set("Content-Type", register.contentType);
+app.post('/license', (req, res) => {
+  const { videoId } = req.body || {};
+  const video = videos.find(v => v.id === videoId);
+  if (!video) return res.status(404).json({ error: 'Video no encontrado' });
+  res.json({ license: `LIC-${videoId}` });
+});
+
+app.get('/cdn/:asset', (req, res) => {
+  const end = cdnLatencyHistogram.labels(req.params.asset).startTimer();
+  // Simulate asset delivery
+  res.json({ asset: req.params.asset });
+  end();
+});
+
+app.get('/metrics', async (req, res) => {
+  res.set('Content-Type', register.contentType);
   res.end(await register.metrics());
 });
 
-app.listen(3000, () => console.log("API OTT corriendo en http://localhost:3000"));
+app.get('/faults', (req, res) => {
+  drmFailuresCounter.inc();
+  res.status(500).json({ error: 'Fallo simulado' });
+});
 
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`API OTT corriendo en http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- refactor API to pure Express implementation
- add Prometheus counters and histogram for requests, DRM failures, and CDN latency
- expose health, video, license, CDN, metrics, and fault endpoints

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_68b20d9395a0832583108e5f86240a18